### PR TITLE
fix(adapters): make worker error events subscribable, typed, and loss…

### DIFF
--- a/src/adapters/errors.browser.test.ts
+++ b/src/adapters/errors.browser.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { toError } from './errors'
+
+// ErrorEvent only exists in browser-like environments, so the instanceof
+// branch of toError is exercised here rather than in the node project.
+describe('adapters/errors (browser)', () => {
+  describe('toError with ErrorEvent', () => {
+    it('unwraps the thrown Error from an ErrorEvent', () => {
+      const thrown = new RangeError('inner')
+      const event = new ErrorEvent('error', { error: thrown, message: 'outer' })
+      expect(toError(event, 'fallback')).toBe(thrown)
+    })
+
+    it('falls back to the ErrorEvent message when it carries no Error', () => {
+      const event = new ErrorEvent('error', { message: 'just a message' })
+      expect(toError(event, 'fallback').message).toBe('just a message')
+    })
+
+    it('uses the fallback when the ErrorEvent has neither error nor message', () => {
+      const event = new ErrorEvent('error')
+      expect(toError(event, 'fallback').message).toBe('fallback')
+    })
+  })
+})

--- a/src/adapters/errors.test.ts
+++ b/src/adapters/errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { toError } from './errors'
+
+// ErrorEvent is a browser-only global; the instanceof-ErrorEvent path is
+// covered in errors.browser.test.ts. These cases run in the node project and
+// exercise the Error, plain-object, and fallback branches.
+describe('adapters/errors', () => {
+  describe('toError', () => {
+    it('returns the same Error instance when given an Error', () => {
+      const original = new TypeError('boom')
+      expect(toError(original, 'fallback')).toBe(original)
+    })
+
+    it('preserves the stack of the original Error', () => {
+      const original = new Error('with stack')
+      expect(toError(original, 'fallback').stack).toBe(original.stack)
+    })
+
+    it('unwraps a thrown Error from an error-event-like object', () => {
+      const thrown = new Error('inner')
+      expect(toError({ error: thrown }, 'fallback')).toBe(thrown)
+    })
+
+    it('uses the message of a plain object that has one', () => {
+      expect(toError({ message: 'plain message' }, 'fallback').message).toBe('plain message')
+    })
+
+    it('uses the fallback message for a MessageEvent (no error, no message)', () => {
+      const event = new MessageEvent('messageerror', { data: { some: 'payload' } })
+      expect(toError(event, 'fallback message').message).toBe('fallback message')
+    })
+
+    it('uses the fallback message for primitives and empty values', () => {
+      expect(toError('a string', 'fallback').message).toBe('fallback')
+      expect(toError(undefined, 'fallback').message).toBe('fallback')
+      expect(toError(null, 'fallback').message).toBe('fallback')
+      expect(toError({ message: '' }, 'fallback').message).toBe('fallback')
+    })
+
+    it('always returns an Error instance', () => {
+      expect(toError(42, 'fallback')).toBeInstanceOf(Error)
+    })
+  })
+})

--- a/src/adapters/errors.ts
+++ b/src/adapters/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * The kind of failure an adapter ran into while bridging messages.
+ *
+ * - `parse`        — an inbound message could not be parsed/deserialized. The
+ *                    transport is still alive; only this one message was lost.
+ * - `fatal`        — an unrecoverable transport error (load / syntax / runtime
+ *                    `error` event). The context is aborted and in-flight
+ *                    invokes reject.
+ * - `messageerror` — a message could not be deserialized by the transport
+ *                    itself (structured-clone failure). The context is aborted.
+ */
+export type AdapterErrorKind = 'parse' | 'fatal' | 'messageerror'
+
+/**
+ * Normalized payload emitted by every adapter when it encounters an error.
+ *
+ * `error` is always unwrapped to a real `Error` (with a stack where one is
+ * available) so subscribers never have to dig a thrown value out of an
+ * `ErrorEvent`. The `kind` discriminator tells callers whether the transport
+ * is still usable (`parse`) or has been torn down (`fatal` / `messageerror`).
+ *
+ * For `messageerror`, `message` carries the original (undeserializable)
+ * `MessageEvent`/message so the failed payload isn't silently dropped.
+ */
+export interface AdapterErrorPayload {
+  kind: AdapterErrorKind
+  error: Error
+  message?: unknown
+}
+
+interface ErrorEventLike {
+  error?: unknown
+  message?: unknown
+}
+
+/**
+ * Coerce whatever a transport hands us — an `Error`, a browser `ErrorEvent`, a
+ * `MessageEvent`, or some host-specific object — into a real `Error`, without
+ * losing the original message/stack.
+ *
+ * `ErrorEvent` is referenced defensively because it does not exist in every
+ * runtime that uses these adapters (e.g. Node's worker_threads).
+ */
+export function toError(input: unknown, fallbackMessage: string): Error {
+  if (input instanceof Error) {
+    return input
+  }
+
+  // Browser ErrorEvent: prefer the actual thrown value, then its message.
+  if (typeof ErrorEvent !== 'undefined' && input instanceof ErrorEvent) {
+    if (input.error instanceof Error) {
+      return input.error
+    }
+    if (typeof input.message === 'string' && input.message) {
+      return new Error(input.message)
+    }
+  }
+
+  // Any error-event-like object carrying a thrown Error or a message string.
+  if (input != null && typeof input === 'object') {
+    const candidate = input as ErrorEventLike
+    if (candidate.error instanceof Error) {
+      return candidate.error
+    }
+    if (typeof candidate.message === 'string' && candidate.message) {
+      return new Error(candidate.message)
+    }
+  }
+
+  return new Error(fallbackMessage)
+}

--- a/src/adapters/event-target/index.ts
+++ b/src/adapters/event-target/index.ts
@@ -3,8 +3,9 @@ import type { DirectionalEventa, Eventa } from '../../eventa'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, EventaType, matchBy } from '../../eventa'
+import { toError } from '../errors'
 import { generateCustomEventDetail, parseCustomEventDetail } from './internal'
-import { workerErrorEvent } from './shared'
+import { adapterErrorEvent } from './shared'
 
 function withRemoval(eventTarget: EventTarget, type: string, listener: EventListenerOrEventListenerObject | null) {
   eventTarget.addEventListener(type, listener)
@@ -53,15 +54,15 @@ export function createContext(eventTarget: EventTarget, options?: {
         ctx.emit(defineInboundEventa(type), payload.body, { raw: { event } })
       }
       catch (error) {
-        console.error('Failed to parse WebSocket message:', error)
-        ctx.emit(workerErrorEvent, { error }, { raw: { event } })
+        console.error('Failed to parse EventTarget message:', error)
+        ctx.emit(adapterErrorEvent, { kind: 'parse', error: toError(error, 'eventa: EventTarget message parse error') }, { raw: { event } })
       }
     }))
   }
 
   if (errorEventName) {
-    cleanupRemoval.push(withRemoval(eventTarget, errorEventName, (error) => {
-      ctx.emit(workerErrorEvent, { error }, { raw: { event: error } })
+    cleanupRemoval.push(withRemoval(eventTarget, errorEventName, (event) => {
+      ctx.emit(adapterErrorEvent, { kind: 'fatal', error: toError(event, 'eventa: EventTarget error') }, { raw: { event } })
     }))
   }
 
@@ -78,4 +79,5 @@ export function createContext(eventTarget: EventTarget, options?: {
   }
 }
 
+export { adapterErrorEvent } from './shared'
 export type * from './shared'

--- a/src/adapters/event-target/shared.ts
+++ b/src/adapters/event-target/shared.ts
@@ -1,6 +1,9 @@
 import type { EventTag } from '../../eventa'
+import type { AdapterErrorPayload } from '../errors'
 
 import { defineEventa } from '../../eventa'
+
+export type { AdapterErrorKind, AdapterErrorPayload } from '../errors'
 
 export interface CustomEventDetail<T> {
   id: string
@@ -8,4 +11,11 @@ export interface CustomEventDetail<T> {
   payload: T
 }
 
-export const workerErrorEvent = { ...defineEventa<{ error: unknown }>() }
+/**
+ * Emitted by the EventTarget adapter when an inbound event fails to parse
+ * (`kind: 'parse'`) or the underlying target dispatches an `error`
+ * (`kind: 'fatal'`). This adapter is generic (it also backs WebSocket-style
+ * targets), so the event is named generically rather than worker-specific.
+ * Has a stable id so it can be subscribed to across module boundaries.
+ */
+export const adapterErrorEvent = defineEventa<AdapterErrorPayload>('eventa:adapter:error')

--- a/src/adapters/webworkers/index.ts
+++ b/src/adapters/webworkers/index.ts
@@ -3,6 +3,7 @@ import type { DirectionalEventa, Eventa } from '../../eventa'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, matchBy } from '../../eventa'
+import { toError } from '../errors'
 import { generateWorkerPayload, parseWorkerPayload } from './internal'
 import { isWorkerEventa, normalizeOnListenerParameters, workerErrorEvent } from './shared'
 
@@ -41,20 +42,22 @@ export function createContext(worker: Worker) {
     }
     catch (error) {
       console.error('Failed to parse WebWorker message:', error)
-      ctx.emit(workerErrorEvent, { error }, { raw: { message: event } })
+      ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: webworker message parse error') }, { raw: { message: event } })
     }
   }
 
-  worker.onerror = (error) => {
+  worker.onerror = (event) => {
     // Fatal worker error (load / syntax / runtime). Abort lifetime so any
     // in-flight invoke rejects; emit the business event for non-invoke listeners.
-    ctx.abort(error instanceof Error ? error : new Error('eventa: invoke cancelled, webworker error'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { error } })
+    const error = toError(event, 'eventa: invoke cancelled, webworker error')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'fatal', error }, { raw: { error: event } })
   }
 
-  worker.onmessageerror = (error) => {
-    ctx.abort(new Error('eventa: invoke cancelled, webworker messageerror'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { messageError: error } })
+  worker.onmessageerror = (event) => {
+    const error = toError(event, 'eventa: invoke cancelled, webworker messageerror')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'messageerror', error, message: event }, { raw: { messageError: event } })
   }
 
   return {
@@ -62,5 +65,5 @@ export function createContext(worker: Worker) {
   }
 }
 
-export { defineOutboundWorkerEventa, defineWorkerEventa, isWorkerEventa } from './shared'
+export { defineOutboundWorkerEventa, defineWorkerEventa, isWorkerEventa, workerErrorEvent } from './shared'
 export type * from './shared'

--- a/src/adapters/webworkers/shared.ts
+++ b/src/adapters/webworkers/shared.ts
@@ -1,8 +1,11 @@
 import type { EventContext } from '../../context'
 import type { Eventa, EventTag } from '../../eventa'
+import type { AdapterErrorPayload } from '../errors'
 
 import { defineEventa, defineOutboundEventa } from '../../eventa'
 import { isExtendableInvokeResponseLike } from '../../invoke'
+
+export type { AdapterErrorKind, AdapterErrorPayload } from '../errors'
 
 export interface WorkerPayload<T> {
   id: string
@@ -36,8 +39,14 @@ export function isWorkerEventa(event: Eventa<any>): event is WorkerEventa<any> {
     && event._workerTransfer === true
 }
 
-export const workerErrorEvent = defineEventa<{ error: unknown }>()
-export const workerMessageErrorEvent = defineEventa<{ error: unknown, message: any }>()
+/**
+ * Emitted by the worker adapters whenever a worker fails: an inbound message
+ * fails to parse (`kind: 'parse'`, non-fatal), the worker hits a fatal
+ * `error` (`kind: 'fatal'`), or a message can't be deserialized
+ * (`kind: 'messageerror'`). Has a stable id so it can be subscribed to across
+ * module boundaries.
+ */
+export const workerErrorEvent = defineEventa<AdapterErrorPayload>('eventa:worker:error')
 
 export function normalizeOnListenerParameters(event: Eventa<any>, options?: { transfer?: Transferable[] } | unknown) {
   let eventPayload: any = event.body

--- a/src/adapters/webworkers/worker/index.ts
+++ b/src/adapters/webworkers/worker/index.ts
@@ -4,6 +4,7 @@ import type { DirectionalEventa, Eventa } from '../../../eventa'
 
 import { createContext as createBaseContext } from '../../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, matchBy } from '../../../eventa'
+import { toError } from '../../errors'
 import { generateWorkerPayload, parseWorkerPayload } from '../internal'
 import { isWorkerEventa, normalizeOnListenerParameters, workerErrorEvent } from '../shared'
 
@@ -39,11 +40,12 @@ export function createContext(options?: {
     messagePort.postMessage(data)
   })
 
-  self.onerror = (error) => {
+  self.onerror = (event) => {
     // Fatal worker-side error. Abort lifetime so any in-flight invoke rejects;
     // emit the business event for non-invoke listeners.
-    ctx.abort(error instanceof Error ? error : new Error('eventa: invoke cancelled, webworker self error'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { error } })
+    const error = toError(event, 'eventa: invoke cancelled, webworker self error')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'fatal', error }, { raw: { error: event } })
   }
 
   self.onmessage = (event) => {
@@ -58,7 +60,7 @@ export function createContext(options?: {
     }
     catch (error) {
       console.error('Failed to parse WebWorker message:', error)
-      ctx.emit(workerErrorEvent, { error }, { raw: { event } })
+      ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: webworker message parse error') }, { raw: { event } })
     }
   }
 
@@ -66,3 +68,6 @@ export function createContext(options?: {
     context: ctx,
   }
 }
+
+export { workerErrorEvent } from '../shared'
+export type { AdapterErrorKind, AdapterErrorPayload } from '../shared'

--- a/src/adapters/window-message/index.ts
+++ b/src/adapters/window-message/index.ts
@@ -4,6 +4,7 @@ import type { WindowMessageEnvelope } from './shared'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, matchBy } from '../../eventa'
+import { toError } from '../errors'
 import { generatePayload, parsePayload } from './internal'
 import { errorEvent } from './shared'
 
@@ -109,14 +110,14 @@ export function createContext(options: WindowMessageAdapterOptions) {
       }
       catch (error) {
         console.error('Failed to parse window message:', error)
-        ctx.emit(errorEvent, { error }, { raw: { error } })
+        ctx.emit(errorEvent, { kind: 'parse', error: toError(error, 'eventa: window message parse error') }, { raw: { error } })
       }
     }))
   }
 
   if (messageError) {
     cleanupRemoval.push(withRemoval(options.currentWindow, 'messageerror', (event) => {
-      ctx.emit(errorEvent, { error: event }, { raw: { messageError: event } })
+      ctx.emit(errorEvent, { kind: 'messageerror', error: toError(event, 'eventa: window messageerror'), message: event }, { raw: { messageError: event } })
     }))
   }
 
@@ -129,4 +130,5 @@ export function createContext(options: WindowMessageAdapterOptions) {
   }
 }
 
+export { errorEvent } from './shared'
 export type * from './shared'

--- a/src/adapters/window-message/shared.ts
+++ b/src/adapters/window-message/shared.ts
@@ -1,6 +1,9 @@
 import type { EventTag } from '../../eventa'
+import type { AdapterErrorPayload } from '../errors'
 
 import { defineEventa } from '../../eventa'
+
+export type { AdapterErrorKind, AdapterErrorPayload } from '../errors'
 
 export interface Payload<T> {
   id: string
@@ -15,4 +18,11 @@ export interface WindowMessageEnvelope<T> {
   payload: Payload<T>
 }
 
-export const errorEvent = { ...defineEventa<{ error: unknown }>() }
+/**
+ * Emitted by the window-message adapter when an inbound message fails to parse
+ * (`kind: 'parse'`) or the window dispatches a `messageerror`
+ * (`kind: 'messageerror'`). Neither is fatal — the window itself stays alive,
+ * so the context is not aborted. Has a stable id so it can be subscribed to
+ * across module boundaries.
+ */
+export const errorEvent = defineEventa<AdapterErrorPayload>('eventa:window-message:error')

--- a/src/adapters/worker-threads/index.ts
+++ b/src/adapters/worker-threads/index.ts
@@ -5,6 +5,7 @@ import type { DirectionalEventa, Eventa } from '../../eventa'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, matchBy } from '../../eventa'
+import { toError } from '../errors'
 import { generateWorkerPayload, parseWorkerPayload } from '../webworkers/internal'
 import { isWorkerEventa, normalizeOnListenerParameters, workerErrorEvent } from '../webworkers/shared'
 
@@ -43,20 +44,22 @@ export function createContext(worker: Worker) {
     }
     catch (error) {
       console.error('Failed to parse Node worker message:', error)
-      ctx.emit(workerErrorEvent, { error }, { raw: { message } })
+      ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: node worker message parse error') }, { raw: { message } })
     }
   })
 
-  worker.on('error', (error) => {
+  worker.on('error', (event) => {
     // Fatal worker error. Abort lifetime so any in-flight invoke rejects;
     // emit the business event for non-invoke listeners.
-    ctx.abort(error instanceof Error ? error : new Error('eventa: invoke cancelled, node worker error'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { error } })
+    const error = toError(event, 'eventa: invoke cancelled, node worker error')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'fatal', error }, { raw: { error: event } })
   })
 
-  worker.on('messageerror', (error) => {
-    ctx.abort(new Error('eventa: invoke cancelled, node worker messageerror'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { messageError: error } })
+  worker.on('messageerror', (event) => {
+    const error = toError(event, 'eventa: invoke cancelled, node worker messageerror')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'messageerror', error, message: event }, { raw: { messageError: event } })
   })
 
   return {
@@ -64,5 +67,5 @@ export function createContext(worker: Worker) {
   }
 }
 
-export { defineOutboundWorkerEventa, defineWorkerEventa, isWorkerEventa } from '../webworkers/shared'
+export { defineOutboundWorkerEventa, defineWorkerEventa, isWorkerEventa, workerErrorEvent } from '../webworkers/shared'
 export type * from '../webworkers/shared'

--- a/src/adapters/worker-threads/worker/index.ts
+++ b/src/adapters/worker-threads/worker/index.ts
@@ -7,6 +7,7 @@ import { parentPort } from 'node:worker_threads'
 
 import { createContext as createBaseContext } from '../../../context'
 import { and, defineInboundEventa, defineOutboundEventa, EventaFlowDirection, matchBy } from '../../../eventa'
+import { toError } from '../../errors'
 import { generateWorkerPayload, parseWorkerPayload } from '../../webworkers/internal'
 import { isWorkerEventa, normalizeOnListenerParameters, workerErrorEvent } from '../../webworkers/shared'
 
@@ -52,23 +53,28 @@ export function createContext(options?: {
     }
     catch (error) {
       console.error('Failed to parse Node worker message:', error)
-      ctx.emit(workerErrorEvent, { error }, { raw: { message } })
+      ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: node worker message parse error') }, { raw: { message } })
     }
   })
 
-  messagePort.on('error', (error) => {
+  messagePort.on('error', (event) => {
     // Fatal port error. Abort lifetime so any in-flight invoke rejects;
     // emit the business event for non-invoke listeners.
-    ctx.abort(error instanceof Error ? error : new Error('eventa: invoke cancelled, node worker port error'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { error } })
+    const error = toError(event, 'eventa: invoke cancelled, node worker port error')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'fatal', error }, { raw: { error: event } })
   })
 
-  messagePort.on('messageerror', (error) => {
-    ctx.abort(new Error('eventa: invoke cancelled, node worker port messageerror'))
-    ctx.emit(workerErrorEvent, { error }, { raw: { messageError: error } })
+  messagePort.on('messageerror', (event) => {
+    const error = toError(event, 'eventa: invoke cancelled, node worker port messageerror')
+    ctx.abort(error)
+    ctx.emit(workerErrorEvent, { kind: 'messageerror', error, message: event }, { raw: { messageError: event } })
   })
 
   return {
     context: ctx,
   }
 }
+
+export { workerErrorEvent } from '../../webworkers/shared'
+export type { AdapterErrorKind, AdapterErrorPayload } from '../../webworkers/shared'


### PR DESCRIPTION
…less

## Summary

The adapter error events (`workerErrorEvent`, the EventTarget/window-message error events) were emitted internally but couldn't actually be consumed: they were never re-exported as runtime values from any supported entrypoint, carried an untyped `{ error: unknown }` payload, and discarded the real thrown error on fatal failures. This PR makes them a real, typed, subscribable part of the adapter API.

This is **additive for any supported consumer** — the event values were not previously reachable through the public entrypoints (only `export type *`, which can't re-export a `const`, and the internal `shared` modules aren't declared in `package.json` `exports`). Nothing that worked before stops working.

## What changed

**New `src/adapters/errors.ts`** — shared error primitives used by every adapter:
- `AdapterErrorPayload` — `{ kind: 'parse' | 'fatal' | 'messageerror', error: Error, message?: unknown }`
- `toError(input, fallback)` — coerces an `Error`, a browser `ErrorEvent`, or any event-like object into a real `Error` without losing the message/stack (defensive about `ErrorEvent` not existing in Node).

**Subscribable + stable** — error events are now re-exported as values from each adapter index (and the worker sub-entrypoints: `webworkers/worker`, `worker-threads/worker`), defined with stable string ids (`eventa:worker:error`, `eventa:adapter:error`, `eventa:window-message:error`) so subscriptions match across module boundaries.

**Typed failure modes** — the `kind` discriminator lets subscribers distinguish a single lost message (`parse`, transport still alive) from a dead transport (`fatal` / `messageerror`, context aborted).

**Lossless errors** — fatal `onerror` previously received an `ErrorEvent` (not an `Error`), so `error instanceof Error ? error : new Error(...)` always discarded the real error/stack in both the abort reason and the emitted payload. It now unwraps via `toError()`. `messageerror` no longer drops the failed message — it's preserved on `payload.message`.

**Cleanup**
- Removed the dead, never-emitted `workerMessageErrorEvent`.
- Renamed the generic EventTarget adapter's event `workerErrorEvent` → `adapterErrorEvent` (it also backs WebSocket-style targets, so the worker-specific name was misleading) and fixed its stale `"Failed to parse WebSocket message"` log.
- Harmonized the `window-message` adapter's `errorEvent` to the same shape.

## Usage

```ts
import { createContext, workerErrorEvent } from '@moeru/eventa/adapters/webworkers'

const { context } = createContext(worker)

context.on(workerErrorEvent, ({ kind, error, message }) => {
  if (kind === 'parse') {
    // one inbound message failed to parse — worker is still alive
    return
  }
  // 'fatal' | 'messageerror' — worker is gone, in-flight invokes already rejected
  console.error(`worker died (${kind}):`, error)
})
```

https://claude.ai/code/session_01Ao1akPdpr5GfugfB2CEZD4