### PR TITLE
fix(stream): align defineStreamInvoke options with defineInvoke

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,5 @@
 import type { EventContext } from './context'
+import type { ExtractInvokeRequestOptions } from './invoke'
 import type {
   InvokeEventa,
   ReceiveEvent,
@@ -55,9 +56,9 @@ export function defineStreamInvoke<
   E = any,
   EO = any,
 >(clientCtx: EventContext<E, EO>, event: InvokeEventa<Res, Req, ResErr, ReqErr>) {
-  return (req: Req | ReadableStream<Req> | AsyncIterable<Req>, options?: { signal?: AbortSignal } & EO) => {
+  return (req: Req | ReadableStream<Req> | AsyncIterable<Req>, options?: ExtractInvokeRequestOptions<EventContext<E, EO>>) => {
     const invokeId = nanoid()
-    const { signal, ...emitOptions } = (options ?? {}) as { signal?: AbortSignal } & Record<string, any>
+    const { signal, ...emitOptions } = (options ?? {}) as ExtractInvokeRequestOptions<EventContext<E, EO>> & Record<string, any>
     let onAbort: (() => void) | undefined
 
     const invokeReceiveEvent = defineEventa(`${event.receiveEvent.id}-${invokeId}`) as ReceiveEvent<Res>


### PR DESCRIPTION
The client-side function returned by defineStreamInvoke typed its options as `{ signal?: AbortSignal } & EO`, intersecting the context's full EmitOptions. For real adapters EmitOptions carries a *required* `raw` field holding inbound transport metadata (the raw message an adapter attaches when receiving), so callers were forced to supply `raw` — meaningless data for an outbound invocation.

defineInvoke avoids this by typing its options as
`ExtractInvokeRequestOptions<EC>`, which pulls only the outbound `invokeRequest` options out of the context Extensions plus `signal`. Use the same extractor here so the two entry points are symmetric and the inbound `raw` metadata is no longer demanded at the call site.