### PR TITLE
feat: added `linkChannel` and `pipeChannel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,107 @@ const someMethod = defineInvoke(ctx, someMethodDefine)
 console.log(await someMethod(42)) // => { output: '42' }
 ```
 
+### Channels
+
+Channels connect existing Eventa contexts. They forward ordinary events and the internal invoke events used by `defineInvoke`, so the same API works for event fan-out, RPC forwarding, and transport bridges such as iframe -> WebSocket -> server.
+
+Use `pipeChannel(...)` for one-way forwarding:
+
+```ts
+import { createContext, defineEventa, pipeChannel } from '@moeru/eventa'
+
+const source = createContext()
+const firstTarget = createContext()
+const secondTarget = createContext()
+
+const message = defineEventa<{ text: string }>('message')
+
+pipeChannel(source, firstTarget, secondTarget)
+
+firstTarget.on(message, ({ body }) => console.log('first', body.text))
+secondTarget.on(message, ({ body }) => console.log('second', body.text))
+
+source.emit(message, { text: 'hello' })
+```
+
+Use `linkChannel(...)` for bidirectional forwarding:
+
+```ts
+import { linkChannel } from '@moeru/eventa'
+
+const link = linkChannel(iframeContext, websocketContext)
+```
+
+`linkChannel(a, b, c)` creates a fully-connected bidirectional mesh. It is not a linear chain like `a <-> b <-> c`; every context is linked to every other context.
+
+Channels propagate context aborts by default. In a pipe, aborting the source aborts every target. In a link, aborting one context aborts the linked mesh. Set `propagateAbort: false` when contexts should share events but keep independent lifetimes:
+
+```ts
+linkChannel(iframeContext, websocketContext, {
+  propagateAbort: false,
+})
+```
+
+#### Transform and filter
+
+Channel plugins run before an event is forwarded. A plugin can:
+
+- return `undefined` to keep forwarding the current event
+- return a new event object to transform it
+- return `false` to drop it for that pipe
+
+Plugins receive the current event and a context object with `source`, `target`, and `direction`.
+
+```ts
+import { defineChannelPlugin, pipeChannel } from '@moeru/eventa'
+
+const tagSource = defineChannelPlugin(event => ({
+  ...event,
+  body: {
+    ...event.body,
+    source: 'iframe',
+  },
+}))
+
+const blockPrivateEvents = defineChannelPlugin((event) => {
+  if (event.id.startsWith('private:')) {
+    return false
+  }
+})
+
+pipeChannel(iframeContext, websocketContext, {
+  plugins: [tagSource, blockPrivateEvents],
+})
+```
+
+You can add plugins after creating a channel. Calling `.use(...)` on the returned group applies the plugin to every pipe in that group:
+
+```ts
+const pipe = pipeChannel(sourceContext, firstTarget, secondTarget)
+
+const removeTrace = pipe.use(event => ({
+  ...event,
+  metadata: {
+    ...event.metadata,
+    tracedAt: Date.now(),
+  },
+}))
+
+removeTrace()
+```
+
+The exposed `pipes` array contains the individual directed pipes. Plugins added to a child pipe only affect that edge:
+
+```ts
+const pipe = pipeChannel(sourceContext, firstTarget, secondTarget)
+
+pipe.pipes[0].use((event) => {
+  if (event.id === 'debug') {
+    return false
+  }
+})
+```
+
 ### Adapters
 
 Eventa comes with various adapters for common use scenarios across browsers and Node.js, including Electron, `window.postMessage`, Web Workers, Worker Threads, BroadcastChannel, EventTarget, EventEmitter, and WebSockets.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,6 +4,7 @@ export default await antfu(
   {
     yaml: false,
     ignores: [
+      'docs/superpowers/**',
       'skills/eventa/SKILL.md',
     ],
     rules: {

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1,0 +1,769 @@
+import type { ChannelLink, ChannelPipeGroup } from './channel'
+
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import { defineChannelPlugin, linkChannel, pipeChannel } from './channel'
+import { createContext } from './context'
+import { defineEventa } from './eventa'
+import { defineInvoke, defineInvokeHandler } from './invoke'
+import { defineInvokeEventa } from './invoke-shared'
+import { defineStreamInvoke, defineStreamInvokeHandler } from './stream'
+
+describe('pipeChannel', () => {
+  it('forwards ordinary events from source to target', () => {
+    const from = createContext()
+    const to = createContext()
+
+    const event = defineEventa<{ message: string }>('channel:ordinary')
+
+    const handler = vi.fn()
+    to.on(event, handler)
+
+    const pipe = pipeChannel(from, to)
+
+    from.emit(event, { message: 'hello' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0]).toMatchObject({ id: event.id, body: { message: 'hello' } })
+
+    pipe.dispose()
+  })
+
+  it('does not echo inbound events back through a channel connection', () => {
+    const from = createContext()
+    const to = createContext()
+    const event = defineEventa<{ value: number }>('channel:no-echo')
+
+    const fromHandler = vi.fn()
+    const toHandler = vi.fn()
+    from.on(event, fromHandler)
+    to.on(event, toHandler)
+
+    const toRight = pipeChannel(from, to)
+    const toLeft = pipeChannel(to, from)
+
+    from.emit(event, { value: 1 })
+
+    expect(fromHandler).toHaveBeenCalledTimes(1)
+    expect(toHandler).toHaveBeenCalledTimes(1)
+
+    toRight.dispose()
+    toLeft.dispose()
+  })
+
+  it('stops forwarding after dispose without aborting either context', () => {
+    const from = createContext()
+    const to = createContext()
+
+    const event = defineEventa<{ value: string }>('channel:dispose')
+
+    const handler = vi.fn()
+    to.on(event, handler)
+
+    const pipe = pipeChannel(from, to)
+
+    pipe.dispose()
+    from.emit(event, { value: 'after-dispose' })
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(from.signal.aborted).toBe(false)
+    expect(to.signal.aborted).toBe(false)
+  })
+
+  it('propagates source abort to every target in a fan-out', () => {
+    const source = createContext()
+    const firstTarget = createContext()
+    const secondTarget = createContext()
+
+    const reason = new Error('source transport closed')
+
+    const pipe = pipeChannel(source, firstTarget, secondTarget)
+
+    source.abort(reason)
+
+    expect(firstTarget.signal.aborted).toBe(true)
+    expect(firstTarget.signal.reason).toBe(reason)
+    expect(secondTarget.signal.aborted).toBe(true)
+    expect(secondTarget.signal.reason).toBe(reason)
+
+    pipe.dispose()
+  })
+
+  it('stops abort propagation after dispose', () => {
+    const source = createContext()
+    const target = createContext()
+
+    const reason = new Error('after dispose')
+
+    const pipe = pipeChannel(source, target)
+
+    pipe.dispose()
+    source.abort(reason)
+
+    expect(target.signal.aborted).toBe(false)
+  })
+
+  it('can disable abort propagation for a pipe', () => {
+    const source = createContext()
+    const target = createContext()
+
+    const reason = new Error('source transport closed')
+
+    const pipe = pipeChannel(source, target, { propagateAbort: false })
+
+    source.abort(reason)
+
+    expect(target.signal.aborted).toBe(false)
+
+    pipe.dispose()
+  })
+
+  it('drops events when a plugin returns false', () => {
+    const from = createContext()
+    const to = createContext()
+
+    const allowed = defineEventa<{ value: string }>('channel:allowed')
+    const blocked = defineEventa<{ value: string }>('channel:blocked')
+
+    const handler = vi.fn()
+    const secondPlugin = vi.fn()
+    to.on(allowed, handler)
+    to.on(blocked, handler)
+
+    pipeChannel(from, to, [
+      event => event.id === allowed.id ? undefined : false,
+      secondPlugin,
+    ])
+
+    from.emit(blocked, { value: 'blocked' })
+    from.emit(allowed, { value: 'allowed' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].id).toBe(allowed.id)
+    expect(handler.mock.calls[0][0].body).toEqual({ value: 'allowed' })
+    expect(secondPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('transforms events through plugins in registration order', () => {
+    const from = createContext()
+    const to = createContext()
+
+    const event = defineEventa<{ value: number }>('channel:transform')
+    const calls: string[] = []
+
+    const handler = vi.fn()
+    to.on(event, handler)
+
+    const pipe = pipeChannel(from, to, [
+      // plugin 1
+      (current) => {
+        calls.push('first')
+        return {
+          ...current,
+          body: { value: current.body!.value + 1 },
+          metadata: { step: 'first' },
+        }
+      },
+      // plugin 2
+      (current) => {
+        calls.push('second')
+        return {
+          ...current,
+          body: { value: current.body!.value * 2 },
+          metadata: { ...(current.metadata ?? {}), step: 'second' },
+        }
+      },
+    ])
+
+    from.emit(event, { value: 2 })
+
+    expect(calls).toEqual(['first', 'second'])
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].body).toEqual({ value: 6 })
+    expect(handler.mock.calls[0][0].metadata).toEqual({ step: 'second' })
+
+    pipe.dispose()
+  })
+
+  it('awaits async plugins before forwarding events', async () => {
+    const from = createContext()
+    const to = createContext()
+
+    const event = defineEventa<{ value: number }>('channel:async-transform')
+
+    const handler = vi.fn()
+    to.on(event, handler)
+
+    const pipe = pipeChannel(from, to, async current => ({
+      ...current,
+      body: { value: current.body!.value + 10 },
+    }))
+
+    await from.emit(event, { value: 1 })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].body).toEqual({ value: 11 })
+
+    pipe.dispose()
+  })
+
+  it('fans out events through multiple ordinary one-way pipes', () => {
+    const source = createContext()
+    const firstTarget = createContext()
+    const secondTarget = createContext()
+
+    const event = defineEventa<{ value: string }>('channel:fan-out')
+
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+    firstTarget.on(event, firstHandler)
+    secondTarget.on(event, secondHandler)
+
+    const pipe = pipeChannel(source, firstTarget, secondTarget)
+
+    source.emit(event, { value: 'shared' })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(firstHandler.mock.calls[0][0].body).toEqual({ value: 'shared' })
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler.mock.calls[0][0].body).toEqual({ value: 'shared' })
+
+    pipe.dispose()
+  })
+
+  it('applies plugins added with use to every target in a fan-out', () => {
+    const source = createContext()
+    const firstTarget = createContext()
+    const secondTarget = createContext()
+
+    const event = defineEventa<{ value: number }>('channel:fan-out:plugins')
+
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+    firstTarget.on(event, firstHandler)
+    secondTarget.on(event, secondHandler)
+
+    const pipe = pipeChannel(source, firstTarget, secondTarget)
+
+    pipe.use(current => ({
+      ...current,
+      body: { value: current.body!.value + 1 },
+    }))
+
+    source.emit(event, { value: 2 })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(firstHandler.mock.calls[0][0].body).toEqual({ value: 3 })
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler.mock.calls[0][0].body).toEqual({ value: 3 })
+
+    pipe.dispose()
+  })
+
+  it('keeps plugins added to a child pipe scoped to that target', () => {
+    const source = createContext()
+    const firstTarget = createContext()
+    const secondTarget = createContext()
+
+    const event = defineEventa<{ value: number }>('channel:fan-out:child-pipe-use')
+
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+    firstTarget.on(event, firstHandler)
+    secondTarget.on(event, secondHandler)
+
+    const pipe = pipeChannel(source, firstTarget, secondTarget)
+
+    pipe.pipes[0].use(current => ({
+      ...current,
+      body: { value: current.body!.value + 10 },
+    }))
+
+    source.emit(event, { value: 1 })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(firstHandler.mock.calls[0][0].body).toEqual({ value: 11 })
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler.mock.calls[0][0].body).toEqual({ value: 1 })
+
+    pipe.dispose()
+  })
+
+  it('filters one target in a four-context fan-out while tagging the source context', () => {
+    const one = createContext()
+    const two = createContext()
+    const three = createContext()
+    const four = createContext()
+
+    const event = defineEventa<{ value: string, sourceContext?: string }>('channel:fan-out:source-tag')
+
+    const twoHandler = vi.fn()
+    const threeHandler = vi.fn()
+    const fourHandler = vi.fn()
+    two.on(event, twoHandler)
+    three.on(event, threeHandler)
+    four.on(event, fourHandler)
+
+    const tagSource = defineChannelPlugin(current => ({
+      ...current,
+      body: {
+        ...current.body,
+        sourceContext: 'one',
+      },
+    }))
+
+    const openPipe = pipeChannel(one, two, three, { plugins: tagSource })
+    const filteredPipe = pipeChannel(one, four, {
+      plugins: [tagSource, current => current.body?.sourceContext === 'one' ? false : undefined],
+    })
+
+    one.emit(event, { value: 'from-one' })
+
+    expect(twoHandler).toHaveBeenCalledTimes(1)
+    expect(twoHandler.mock.calls[0][0].body).toEqual({
+      value: 'from-one',
+      sourceContext: 'one',
+    })
+    expect(threeHandler).toHaveBeenCalledTimes(1)
+    expect(threeHandler.mock.calls[0][0].body).toEqual({
+      value: 'from-one',
+      sourceContext: 'one',
+    })
+    expect(fourHandler).not.toHaveBeenCalled()
+
+    openPipe.dispose()
+    filteredPipe.dispose()
+  })
+
+  it('allows plugins added with use and removes only that registered plugin', () => {
+    const source = createContext()
+    const target = createContext()
+
+    const event = defineEventa<{ value: number }>('channel:use')
+
+    const handler = vi.fn()
+    target.on(event, handler)
+
+    const pipe = pipeChannel(source, target)
+    const plugin = defineChannelPlugin(current => ({
+      ...current,
+      body: { value: current.body!.value + 10 },
+    }))
+    const unuseFirst = pipe.use(plugin)
+    pipe.use(plugin)
+
+    source.emit(event, { value: 1 })
+    unuseFirst()
+    source.emit(event, { value: 1 })
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler.mock.calls[0][0].body).toEqual({ value: 21 })
+    expect(handler.mock.calls[1][0].body).toEqual({ value: 11 })
+  })
+
+  it('passes source target and direction to plugins', () => {
+    const source = createContext()
+    const target = createContext()
+
+    const event = defineEventa<{ value: string }>('channel:plugin-context')
+
+    const plugin = vi.fn()
+    pipeChannel(source, target, { plugins: plugin, direction: 'left-to-right' })
+    source.emit(event, { value: 'context' })
+
+    expect(plugin).toHaveBeenCalledTimes(1)
+    expect(plugin.mock.calls[0][1]).toEqual({
+      source,
+      target,
+      direction: 'left-to-right',
+    })
+  })
+
+  it('propagates plugin errors through source emit', async () => {
+    const source = createContext()
+    const target = createContext()
+
+    const event = defineEventa<{ value: string }>('channel:plugin-error')
+    const expected = new Error('plugin failed')
+
+    pipeChannel(source, target, {
+      plugins: () => {
+        throw expected
+      },
+    })
+
+    await expect(source.emit(event, { value: 'boom' })).rejects.toBe(expected)
+  })
+  it('infers source and target context types for channel plugins', () => {
+    interface SourceExtensions { sourceExtension: true }
+    interface SourceEmitOptions { sourceOption: string }
+    interface TargetExtensions { targetExtension: true }
+    interface TargetEmitOptions { targetOption: number }
+
+    const source = createContext<SourceExtensions, SourceEmitOptions>()
+    const target = createContext<TargetExtensions, TargetEmitOptions>()
+
+    const pipe = pipeChannel(source, target, {
+      plugins: (_event, context) => {
+        expectTypeOf(context.source).toEqualTypeOf<typeof source>()
+        expectTypeOf(context.target).toEqualTypeOf<typeof target>()
+        expectTypeOf(context.source.extensions).toEqualTypeOf<SourceExtensions | undefined>()
+        expectTypeOf(context.target.extensions).toEqualTypeOf<TargetExtensions | undefined>()
+        expectTypeOf<Parameters<typeof context.source.emit>[2]>().toEqualTypeOf<SourceEmitOptions | undefined>()
+        expectTypeOf<Parameters<typeof context.target.emit>[2]>().toEqualTypeOf<TargetEmitOptions | undefined>()
+      },
+    })
+
+    pipe.use((_event, context) => {
+      expectTypeOf(context.source).toEqualTypeOf<typeof source>()
+      expectTypeOf(context.target).toEqualTypeOf<typeof target>()
+      expectTypeOf(context.source.extensions).toEqualTypeOf<SourceExtensions | undefined>()
+      expectTypeOf(context.target.extensions).toEqualTypeOf<TargetExtensions | undefined>()
+    })
+
+    expectTypeOf(pipe).toEqualTypeOf<ChannelPipeGroup<SourceExtensions, SourceEmitOptions, TargetExtensions, TargetEmitOptions>>()
+
+    pipe.dispose()
+  })
+})
+
+describe('linkChannel', () => {
+  it('links two existing contexts bidirectionally', () => {
+    const left = createContext()
+    const right = createContext()
+
+    const ping = defineEventa<{ value: string }>('channel:pipe:ping')
+    const pong = defineEventa<{ value: string }>('channel:pipe:pong')
+
+    const leftHandler = vi.fn()
+    const rightHandler = vi.fn()
+    left.on(pong, leftHandler)
+    right.on(ping, rightHandler)
+
+    const linkHandle = linkChannel(left, right)
+
+    left.emit(ping, { value: 'from-left' })
+    right.emit(pong, { value: 'from-right' })
+
+    expect(rightHandler).toHaveBeenCalledTimes(1)
+    expect(rightHandler.mock.calls[0][0].body).toEqual({ value: 'from-left' })
+    expect(leftHandler).toHaveBeenCalledTimes(1)
+    expect(leftHandler.mock.calls[0][0].body).toEqual({ value: 'from-right' })
+
+    linkHandle.dispose()
+  })
+
+  it('carries unary invoke events across a channel connection', async () => {
+    const left = createContext()
+    const right = createContext()
+
+    const events = defineInvokeEventa<{ greeting: string }, { name: string }>('channel:pipe:invoke')
+
+    defineInvokeHandler(right, events, ({ name }) => ({ greeting: `hello ${name}` }))
+
+    const linkHandle = linkChannel(left, right)
+    const invoke = defineInvoke(left, events)
+
+    await expect(invoke({ name: 'alice' })).resolves.toEqual({ greeting: 'hello alice' })
+
+    linkHandle.dispose()
+  })
+
+  it('carries request-stream invoke events across a channel connection', async () => {
+    const left = createContext()
+    const right = createContext()
+
+    const events = defineInvokeEventa<number, ReadableStream<number>>('channel:pipe:invoke-request-stream')
+
+    defineInvokeHandler(right, events, async (payload) => {
+      let sum = 0
+
+      for await (const value of payload) {
+        sum += value
+      }
+
+      return sum
+    })
+
+    const linkHandle = linkChannel(left, right)
+    const invoke = defineInvoke(left, events)
+    const input = new ReadableStream<number>({
+      start(controller) {
+        controller.enqueue(1)
+        controller.enqueue(2)
+        controller.enqueue(3)
+        controller.close()
+      },
+    })
+
+    await expect(invoke(input)).resolves.toBe(6)
+
+    linkHandle.dispose()
+  })
+
+  it('carries stream invoke response events across a channel connection', async () => {
+    const left = createContext()
+    const right = createContext()
+
+    const events = defineInvokeEventa<{ step: number } | { result: string }, { name: string }>('channel:pipe:stream-invoke')
+
+    defineStreamInvokeHandler(right, events, ({ name }) => {
+      return (async function* () {
+        yield { step: 1 }
+        yield { step: 2 }
+        yield { result: `done ${name}` }
+      }())
+    })
+
+    const linkHandle = linkChannel(left, right)
+    const invoke = defineStreamInvoke(left, events)
+    const responses: Array<{ step: number } | { result: string }> = []
+
+    for await (const response of invoke({ name: 'alice' })) {
+      responses.push(response)
+    }
+
+    expect(responses).toEqual([
+      { step: 1 },
+      { step: 2 },
+      { result: 'done alice' },
+    ])
+
+    linkHandle.dispose()
+  })
+
+  it('applies shared plugins with direction context', () => {
+    const left = createContext()
+    const right = createContext()
+    const event = defineEventa<{ value: number }>('channel:pipe:plugins')
+
+    const leftHandler = vi.fn()
+    const rightHandler = vi.fn()
+
+    const plugin = vi.fn(defineChannelPlugin((current, context) => ({
+      ...current,
+      body: { value: current.body!.value + (context.source === left ? 1 : 100) },
+    })))
+
+    right.on(event, rightHandler)
+    left.on(event, leftHandler)
+
+    const linkHandle = linkChannel(left, right, { plugins: plugin })
+
+    left.emit(event, { value: 1 })
+    right.emit(event, { value: 1 })
+
+    expect(rightHandler).toHaveBeenCalledTimes(2)
+    expect(rightHandler.mock.calls[0][0].body).toEqual({ value: 2 })
+    expect(rightHandler.mock.calls[1][0].body).toEqual({ value: 1 })
+    expect(leftHandler).toHaveBeenCalledTimes(2)
+    expect(leftHandler.mock.calls[0][0].body).toEqual({ value: 1 })
+    expect(leftHandler.mock.calls[1][0].body).toEqual({ value: 101 })
+    expect(plugin).toHaveBeenCalledTimes(2)
+    expect(plugin.mock.calls[0][1]).toEqual({
+      source: left,
+      target: right,
+      direction: 'left-to-right',
+    })
+    expect(plugin.mock.calls[1][1]).toEqual({
+      source: right,
+      target: left,
+      direction: 'right-to-left',
+    })
+
+    linkHandle.dispose()
+  })
+
+  it('stops both pipe directions and allows repeated dispose without aborting contexts', () => {
+    const left = createContext()
+    const right = createContext()
+    const event = defineEventa<{ value: string }>('channel:pipe:dispose')
+
+    const connection = linkChannel(left, right)
+
+    const leftHandler = vi.fn()
+    const rightHandler = vi.fn()
+    left.on(event, leftHandler)
+    right.on(event, rightHandler)
+
+    connection.dispose()
+    connection.dispose() // intended, checking for idempotent dispose
+
+    left.emit(event, { value: 'from-left' })
+    right.emit(event, { value: 'from-right' })
+
+    expect(leftHandler).toHaveBeenCalledTimes(1)
+    expect(leftHandler.mock.calls[0][0].body).toEqual({ value: 'from-left' })
+    expect(rightHandler).toHaveBeenCalledTimes(1)
+    expect(rightHandler.mock.calls[0][0].body).toEqual({ value: 'from-right' })
+    expect(left.signal.aborted).toBe(false)
+    expect(right.signal.aborted).toBe(false)
+  })
+
+  it('propagates abort across a linked mesh', () => {
+    const first = createContext()
+    const second = createContext()
+    const third = createContext()
+
+    const reason = new Error('mesh transport closed')
+
+    const connection = linkChannel(first, second, third)
+
+    second.abort(reason)
+
+    expect(first.signal.aborted).toBe(true)
+    expect(first.signal.reason).toBe(reason)
+    expect(third.signal.aborted).toBe(true)
+    expect(third.signal.reason).toBe(reason)
+
+    connection.dispose()
+  })
+
+  it('can disable abort propagation for a linked mesh', () => {
+    const first = createContext()
+    const second = createContext()
+
+    const reason = new Error('mesh transport closed')
+
+    const connection = linkChannel(first, second, { propagateAbort: false })
+
+    second.abort(reason)
+
+    expect(first.signal.aborted).toBe(false)
+
+    connection.dispose()
+  })
+
+  it('rejects a pending invoke when a linked remote context aborts', async () => {
+    const iframe = createContext()
+    const websocket = createContext()
+
+    const events = defineInvokeEventa<{ greeting: string }, { name: string }>('channel:link:invoke-abort')
+    const invoke = defineInvoke(iframe, events)
+
+    const reason = new Error('websocket server disconnected')
+
+    const connection = linkChannel(iframe, websocket)
+    const pending = invoke({ name: 'alice' })
+
+    websocket.abort(reason)
+
+    await expect(pending).rejects.toBe(reason)
+
+    connection.dispose()
+  })
+
+  it('aborts the remote invoke handler when the linked caller context aborts', async () => {
+    const iframe = createContext()
+    const websocket = createContext()
+
+    const events = defineInvokeEventa<{ greeting: string }, { name: string }>('channel:link:invoke-handler-abort')
+    const invoke = defineInvoke(iframe, events)
+
+    const reason = new Error('iframe unloaded')
+
+    let resolveStarted!: () => void
+    let resolveAbortReason!: (reason: unknown) => void
+    const handlerStarted = new Promise<void>(resolve => resolveStarted = resolve)
+    const handlerAbortReason = new Promise<unknown>(resolve => resolveAbortReason = resolve)
+
+    defineInvokeHandler(websocket, events, (_payload, options) => {
+      resolveStarted()
+      options?.abortController?.signal.addEventListener('abort', () => {
+        resolveAbortReason(options.abortController?.signal.reason)
+      }, { once: true })
+
+      return new Promise(() => {})
+    })
+
+    const connection = linkChannel(iframe, websocket)
+    const pending = invoke({ name: 'alice' })
+
+    await handlerStarted
+    iframe.abort(reason)
+
+    await expect(pending).rejects.toBe(reason)
+    await expect(handlerAbortReason).resolves.toBe(reason)
+
+    connection.dispose()
+  })
+
+  it('links any number of contexts bidirectionally and applies plugins added with use', () => {
+    const first = createContext()
+    const second = createContext()
+    const third = createContext()
+    const event = defineEventa<{ value: number }>('channel:link:mesh')
+
+    const secondHandler = vi.fn()
+    const thirdHandler = vi.fn()
+    second.on(event, secondHandler)
+    third.on(event, thirdHandler)
+
+    const connection = linkChannel(first, second, third)
+
+    connection.use(current => ({
+      ...current,
+      body: { value: current.body!.value + 10 },
+    }))
+
+    first.emit(event, { value: 1 })
+
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler.mock.calls[0][0].body).toEqual({ value: 11 })
+    expect(thirdHandler).toHaveBeenCalledTimes(1)
+    expect(thirdHandler.mock.calls[0][0].body).toEqual({ value: 11 })
+
+    connection.dispose()
+  })
+
+  it('keeps plugins added to a child link pipe scoped to that directed edge', () => {
+    const left = createContext()
+    const right = createContext()
+    const event = defineEventa<{ value: number }>('channel:link:child-pipe-use')
+
+    const leftHandler = vi.fn()
+    const rightHandler = vi.fn()
+    left.on(event, leftHandler)
+    right.on(event, rightHandler)
+
+    const connection = linkChannel(left, right)
+
+    connection.pipes[0].use(current => ({
+      ...current,
+      body: { value: current.body!.value + 10 },
+    }))
+
+    left.emit(event, { value: 1 })
+    right.emit(event, { value: 1 })
+
+    expect(rightHandler).toHaveBeenCalledTimes(2)
+    expect(rightHandler.mock.calls[0][0].body).toEqual({ value: 11 })
+    expect(rightHandler.mock.calls[1][0].body).toEqual({ value: 1 })
+    expect(leftHandler).toHaveBeenCalledTimes(2)
+    expect(leftHandler.mock.calls[0][0].body).toEqual({ value: 1 })
+    expect(leftHandler.mock.calls[1][0].body).toEqual({ value: 1 })
+
+    connection.dispose()
+  })
+
+  it('infers source and target context types for channel plugins', () => {
+    interface SourceExtensions { sourceExtension: true }
+    interface SourceEmitOptions { sourceOption: string }
+    interface TargetExtensions { targetExtension: true }
+    interface TargetEmitOptions { targetOption: number }
+
+    const source = createContext<SourceExtensions, SourceEmitOptions>()
+    const target = createContext<TargetExtensions, TargetEmitOptions>()
+
+    const connection = linkChannel(source, target, {
+      plugins: (_event, context) => {
+        expectTypeOf(context.source).toEqualTypeOf<typeof source | typeof target>()
+        expectTypeOf(context.target).toEqualTypeOf<typeof source | typeof target>()
+      },
+    })
+
+    expectTypeOf(connection).toEqualTypeOf<ChannelLink<SourceExtensions, SourceEmitOptions, TargetExtensions, TargetEmitOptions>>()
+
+    connection.dispose()
+  })
+})

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,0 +1,494 @@
+import type { EventContext } from './context'
+import type { DirectionalEventa, Eventa } from './eventa'
+
+import { and, defineInboundEventa, EventaFlowDirection, matchBy } from './eventa'
+
+export type ChannelPluginResult
+  = | false
+    | void
+    | Eventa<any>
+    | Promise<false | void | Eventa<any>>
+
+export interface ChannelPluginContext<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> {
+  source: EventContext<FromExtensions, FromEmitOptions>
+  target: EventContext<ToExtensions, ToEmitOptions>
+  direction?: string
+}
+
+export type ChannelPlugin<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> = (
+  event: Eventa<any>,
+  context: ChannelPluginContext<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>,
+) => ChannelPluginResult
+
+export interface ChannelLinkPluginContext<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> {
+  source:
+    | EventContext<LeftExtensions, LeftEmitOptions>
+    | EventContext<RightExtensions, RightEmitOptions>
+  target:
+    | EventContext<LeftExtensions, LeftEmitOptions>
+    | EventContext<RightExtensions, RightEmitOptions>
+  direction?: string
+}
+
+export type ChannelLinkPlugin<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> = (
+  event: Eventa<any>,
+  context: ChannelLinkPluginContext<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>,
+) => ChannelPluginResult
+
+export function defineChannelPlugin<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+>(plugin: ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>): ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> {
+  return plugin
+}
+
+export interface ChannelPipe<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> {
+  use: (plugin: ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>) => () => void
+  dispose: () => void
+}
+
+export interface ChannelPipeGroup<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> extends ChannelPipe<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> {
+  pipes: Array<ChannelPipe<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>
+}
+
+export interface ChannelPipeOptions<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> {
+  plugins?:
+    | ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+    | Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>
+  direction?: string
+  /**
+   * Propagates source context abort to every target context by default.
+   *
+   * NOTICE: this is lifecycle propagation, not an event flowing through the
+   * plugin pipeline. Channel plugins and filters do not block it. Set false
+   * when contexts should share events but keep independent lifetimes.
+   */
+  propagateAbort?: boolean
+}
+
+export interface ChannelLinkOptions<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> {
+  plugins?:
+    | ChannelLinkPlugin<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>
+    | Array<ChannelLinkPlugin<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>>
+  /**
+   * Propagates abort across the linked mesh by default.
+   *
+   * NOTICE: this is lifecycle propagation, not an event flowing through the
+   * plugin pipeline. Link plugins and filters do not block it. Set false when
+   * contexts should share events but keep independent lifetimes.
+   */
+  propagateAbort?: boolean
+}
+
+export interface ChannelLink<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> {
+  pipes: Array<ChannelPipe<any, any, any, any>>
+  use: (plugin: ChannelLinkPlugin<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>) => () => void
+  dispose: () => void
+}
+
+// TODO: Add route selectors on top of the group model:
+// - pipeChannel(...).to(target).use(plugin) for target-specific fan-out rules.
+// - linkChannel(...).from(source).to(target).use(plugin) for one directed edge.
+// - linkChannel(...).between(left, right).use(plugin) for both directions.
+// Keep those as chainable selectors instead of widening options into a route
+// table; route behavior belongs to edges and should compose with group .use().
+//
+// NOTICE: linkChannel(...contexts) creates a fully-connected bidirectional
+// mesh. It is not a linear chain like a <-> b <-> c.
+
+export type ChannelConnectionOptions<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> = ChannelLinkOptions<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>
+
+export type ChannelConnection<
+  LeftExtensions = any,
+  LeftEmitOptions = any,
+  RightExtensions = any,
+  RightEmitOptions = any,
+> = ChannelLink<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>
+
+function normalizePlugins<
+  FromExtensions,
+  FromEmitOptions,
+  ToExtensions,
+  ToEmitOptions,
+>(plugins?: ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> | Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>): Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>> {
+  if (!plugins) {
+    return []
+  }
+
+  return Array.isArray(plugins) ? [...plugins] : [plugins]
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as PromiseLike<T>)?.then === 'function'
+}
+
+function toInboundEvent(event: Eventa<any>): Eventa<any> {
+  return {
+    ...defineInboundEventa(event.id),
+    ...event,
+    _flowDirection: EventaFlowDirection.Inbound,
+  } as Eventa<any>
+}
+
+function isEventContext(value: unknown): value is EventContext<any, any> {
+  return typeof value === 'object'
+    && value !== null
+    && typeof (value as EventContext<any, any>).emit === 'function'
+    && typeof (value as EventContext<any, any>).on === 'function'
+}
+
+function isPipeOptions(value: unknown): value is ChannelPipeOptions<any, any, any, any> {
+  return typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !isEventContext(value)
+    && ('plugins' in value || 'direction' in value || 'propagateAbort' in value)
+}
+
+interface CreateChannelPipeOptions<
+  FromExtensions = any,
+  FromEmitOptions = any,
+  ToExtensions = any,
+  ToEmitOptions = any,
+> {
+  plugins?: Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>
+  direction?: string
+  propagateAbort?: boolean
+}
+
+function createChannelPipe<
+  FromExtensions = undefined,
+  FromEmitOptions = undefined,
+  ToExtensions = undefined,
+  ToEmitOptions = undefined,
+>(
+  from: EventContext<FromExtensions, FromEmitOptions>,
+  to: EventContext<ToExtensions, ToEmitOptions>,
+  pipeOptions: CreateChannelPipeOptions<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> = {},
+): ChannelPipe<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> {
+  const plugins = pipeOptions.plugins ?? []
+  const localPluginList: Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>> = []
+
+  const onSourceAbort = () => {
+    to.abort(from.signal.reason)
+  }
+
+  if (pipeOptions.propagateAbort ?? true) {
+    if (from.signal.aborted) {
+      onSourceAbort()
+    }
+    else {
+      from.signal.addEventListener('abort', onSourceAbort, { once: true })
+    }
+  }
+
+  const off = from.on(and(
+    matchBy((event: DirectionalEventa<any>) => event._flowDirection === EventaFlowDirection.Outbound || !event._flowDirection),
+    matchBy('*'),
+  ), async (event, options) => {
+    let current: Eventa<any> = event
+    const context: ChannelPluginContext<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions> = { source: from, target: to, direction: pipeOptions.direction }
+
+    // Keep the two lists separate to avoid copying plugin arrays on every event;
+    // shared plugins still run before pipe-local plugins.
+    for (const pluginList of [plugins, localPluginList]) {
+      for (const plugin of pluginList) {
+        const pluginResult = plugin(current, context)
+        const result = isPromiseLike(pluginResult)
+          ? await pluginResult
+          : pluginResult
+
+        if (result === false) {
+          return
+        }
+        if (typeof result !== 'undefined') {
+          current = result
+        }
+      }
+    }
+
+    await to.emit(toInboundEvent(current), current.body, options as never)
+  })
+
+  let disposed = false
+
+  return {
+    use(plugin) {
+      if (disposed) {
+        throw new Error('Channel pipe disposed.')
+      }
+
+      localPluginList.push(plugin)
+
+      return () => {
+        const index = localPluginList.indexOf(plugin)
+
+        if (index >= 0) {
+          localPluginList.splice(index, 1)
+        }
+      }
+    },
+
+    dispose() {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      off()
+      from.signal.removeEventListener('abort', onSourceAbort)
+      localPluginList.length = 0
+    },
+  }
+}
+
+export function pipeChannel<
+  FromExtensions = undefined,
+  FromEmitOptions = undefined,
+  ToExtensions = undefined,
+  ToEmitOptions = undefined,
+>(
+  from: EventContext<FromExtensions, FromEmitOptions>,
+  to: EventContext<ToExtensions, ToEmitOptions>,
+  options?:
+    | ChannelPipeOptions<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+    | ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+    | Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>,
+): ChannelPipeGroup<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+
+export function pipeChannel<
+  FromExtensions = undefined,
+  FromEmitOptions = undefined,
+  ToExtensions = undefined,
+  ToEmitOptions = undefined,
+>(
+  from: EventContext<FromExtensions, FromEmitOptions>,
+  firstTo: EventContext<ToExtensions, ToEmitOptions>,
+  ...targetsAndOptions: Array<
+    | EventContext<ToExtensions, ToEmitOptions>
+    | ChannelPipeOptions<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+    | ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+    | Array<ChannelPlugin<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>>
+  >
+): ChannelPipeGroup<FromExtensions, FromEmitOptions, ToExtensions, ToEmitOptions>
+
+export function pipeChannel(
+  from: EventContext<any, any>,
+  firstTo: EventContext<any, any>,
+  ...targetsAndOptions: Array<
+    | EventContext<any, any>
+    | ChannelPipeOptions<any, any, any, any>
+    | ChannelPlugin<any, any, any, any>
+    | Array<ChannelPlugin<any, any, any, any>>
+    | undefined
+  >
+): ChannelPipeGroup<any, any, any, any> {
+  const targets: Array<EventContext<any, any>> = [firstTo]
+  let options: ChannelPipeOptions<any, any, any, any> = {}
+
+  for (const item of targetsAndOptions) {
+    if (!item) {
+      continue
+    }
+
+    if (isEventContext(item)) {
+      targets.push(item)
+      continue
+    }
+
+    if (isPipeOptions(item)) {
+      options = item
+      continue
+    }
+
+    options = {
+      ...options,
+      plugins: item,
+    }
+  }
+
+  const pluginList = normalizePlugins(options.plugins)
+  const pipes = targets.map(target => createChannelPipe(from, target, {
+    plugins: pluginList,
+    direction: options.direction,
+    propagateAbort: options.propagateAbort,
+  }))
+  let disposed = false
+
+  return {
+    pipes,
+    use(plugin) {
+      if (disposed) {
+        throw new Error('Channel pipe disposed.')
+      }
+
+      pluginList.push(plugin)
+
+      return () => {
+        const index = pluginList.indexOf(plugin)
+
+        if (index >= 0) {
+          pluginList.splice(index, 1)
+        }
+      }
+    },
+    dispose() {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      for (const pipe of pipes) {
+        pipe.dispose()
+      }
+      pluginList.length = 0
+    },
+  }
+}
+
+function getLinkDirection(sourceIndex: number, targetIndex: number): string {
+  if (sourceIndex === 0 && targetIndex === 1) {
+    return 'left-to-right'
+  }
+  if (sourceIndex === 1 && targetIndex === 0) {
+    return 'right-to-left'
+  }
+
+  return `context-${sourceIndex}-to-${targetIndex}`
+}
+
+export function linkChannel<
+  LeftExtensions = undefined,
+  LeftEmitOptions = undefined,
+  RightExtensions = undefined,
+  RightEmitOptions = undefined,
+>(
+  leftContext: EventContext<LeftExtensions, LeftEmitOptions>,
+  rightContext: EventContext<RightExtensions, RightEmitOptions>,
+  options?: ChannelLinkOptions<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>,
+): ChannelLink<LeftExtensions, LeftEmitOptions, RightExtensions, RightEmitOptions>
+
+export function linkChannel(
+  ...contextsAndOptions: Array<EventContext<any, any> | ChannelLinkOptions<any, any, any, any>>
+): ChannelLink<any, any, any, any>
+
+export function linkChannel(
+  ...contextsAndOptions: Array<EventContext<any, any> | ChannelLinkOptions<any, any, any, any> | undefined>
+): ChannelLink<any, any, any, any> {
+  const contexts: Array<EventContext<any, any>> = []
+  let options: ChannelLinkOptions<any, any, any, any> = {}
+
+  for (const item of contextsAndOptions) {
+    if (!item) {
+      continue
+    }
+
+    if (isEventContext(item)) {
+      contexts.push(item)
+      continue
+    }
+
+    options = item
+  }
+
+  const pluginList = normalizePlugins(options.plugins) as Array<ChannelPlugin<any, any, any, any>>
+  const pipes: Array<ChannelPipe<any, any, any, any>> = []
+
+  for (let sourceIndex = 0; sourceIndex < contexts.length; sourceIndex += 1) {
+    for (let targetIndex = 0; targetIndex < contexts.length; targetIndex += 1) {
+      if (sourceIndex === targetIndex) {
+        continue
+      }
+
+      pipes.push(createChannelPipe(contexts[sourceIndex], contexts[targetIndex], {
+        plugins: pluginList,
+        direction: getLinkDirection(sourceIndex, targetIndex),
+        propagateAbort: options.propagateAbort,
+      }))
+    }
+  }
+
+  let disposed = false
+
+  return {
+    pipes,
+    use(plugin) {
+      if (disposed) {
+        throw new Error('Channel link disposed.')
+      }
+
+      pluginList.push(plugin)
+
+      return () => {
+        const index = pluginList.indexOf(plugin)
+
+        if (index >= 0) {
+          pluginList.splice(index, 1)
+        }
+      }
+    },
+    dispose() {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      for (const pipe of pipes) {
+        pipe.dispose()
+      }
+      pluginList.length = 0
+    },
+  }
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -24,16 +24,23 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
 
   const hooks = props.adapter?.(emit).hooks
 
-  function emit<P>(event: Eventa<P>, payload: P, options?: Options) {
+  function emit<P>(event: Eventa<P>, payload: P, options?: Options): Promise<void> {
     const emittingPayload = { ...event, body: payload }
+    const pending: Array<Promise<void>> = []
+
+    function track(result: unknown | Promise<unknown>) {
+      if (typeof result === 'object' && result !== null && 'then' in result && typeof result.then === 'function') {
+        pending.push(result as unknown as Promise<void>)
+      }
+    }
 
     for (const listener of listeners.get(event.id) || []) {
-      listener(emittingPayload, options)
+      track(listener(emittingPayload, options))
       hooks?.onReceived?.(event.id, emittingPayload)
     }
 
     for (const onceListener of onceListeners.get(event.id) || []) {
-      onceListener(emittingPayload, options)
+      track(onceListener(emittingPayload, options))
       hooks?.onReceived?.(event.id, emittingPayload)
       onceListeners.get(event.id)?.delete(onceListener)
     }
@@ -46,11 +53,11 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
         }
 
         for (const listener of matchExpressionListeners.get(matchExpression.id) || []) {
-          listener(emittingPayload, options)
+          track(listener(emittingPayload, options))
           hooks?.onReceived?.(matchExpression.id, emittingPayload)
         }
         for (const onceListener of matchExpressionOnceListeners.get(matchExpression.id) || []) {
-          onceListener(emittingPayload, options)
+          track(onceListener(emittingPayload, options))
           hooks?.onReceived?.(matchExpression.id, emittingPayload)
           matchExpressionOnceListeners.get(matchExpression.id)?.delete(onceListener)
         }
@@ -58,6 +65,8 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
     }
 
     hooks?.onSent(event.id, emittingPayload, options)
+
+    return Promise.all(pending).then(() => void 0)
   }
 
   return {
@@ -71,7 +80,7 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
 
     emit,
 
-    on<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: Options) => void): () => void {
+    on<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: Options) => any): () => void {
       if (eventOrMatchExpression.type === EventaType.Event) {
         const event = eventOrMatchExpression as Eventa<P>
         if (!listeners.has(event.id)) {
@@ -100,7 +109,7 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
       return () => void 0
     },
 
-    once<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: Options) => void): () => void {
+    once<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: Options) => any): () => void {
       if (eventOrMatchExpression.type === EventaType.Event) {
         const event = eventOrMatchExpression as Eventa<P>
         if (!onceListeners.has(event.id)) {
@@ -129,7 +138,7 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
       return () => void 0
     },
 
-    off<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler?: (payload: Eventa<P>, options?: Options) => void) {
+    off<P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler?: (payload: Eventa<P>, options?: Options) => any) {
       switch (eventOrMatchExpression.type) {
         case EventaType.Event:
           if (handler !== undefined) {
@@ -161,6 +170,7 @@ export function createContext<Extensions = any, Options = { raw?: any }>(props: 
       if (lifetimeController.signal.aborted) {
         return
       }
+
       lifetimeController.abort(reason)
     },
   }
@@ -170,10 +180,10 @@ export interface EventContext<Extensions = undefined, EmitOptions = undefined> {
   listeners: Map<EventTag<any, any>, Set<(params: any) => any>>
   onceListeners: Map<EventTag<any, any>, Set<(params: any) => any>>
 
-  emit: <P>(event: Eventa<P>, payload: P, options?: EmitOptions) => void
-  on: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: EmitOptions) => void) => () => void
-  once: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: EmitOptions) => void) => () => void
-  off: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler?: (payload: Eventa<P>, options?: EmitOptions) => void) => void
+  emit: <P>(event: Eventa<P>, payload: P, options?: EmitOptions) => Promise<void>
+  on: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: EmitOptions) => any) => () => void
+  once: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler: (payload: Eventa<P>, options?: EmitOptions) => any) => () => void
+  off: <P>(eventOrMatchExpression: Eventa<P> | EventaMatchExpression<P>, handler?: (payload: Eventa<P>, options?: EmitOptions) => any) => void
 
   /**
    * Lifetime signal for this context. Aborts when `abort()` is called by an

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type * from './channel'
+export * from './channel'
 export type * from './context'
 export * from './context'
 export type * from './eventa'

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -95,6 +95,7 @@ interface InternalInvokeHandler<
   onSend: (params: Eventa<NonNullable<InvokeEventa<Res, Req, ResErr, ReqErr, M, IM>['sendEvent']['body']>>, eventOptions?: EO) => void
   onSendStreamEnd: (params: Eventa<NonNullable<InvokeEventa<Res, Req, ResErr, ReqErr, M, IM>['sendEventStreamEnd']['body']>>, eventOptions?: EO) => void
   onSendAbort: (params: Eventa<NonNullable<InvokeEventa<Res, Req, ResErr, ReqErr, M, IM>['sendEventAbort']['body']>>, eventOptions?: EO) => void
+  cleanup: () => void
 }
 
 export type HandlerMap<
@@ -420,97 +421,101 @@ export function defineInvokeHandler<
     ctx.invokeHandlers?.set(event.sendEvent.id, handlers)
   }
 
-  let internalHandler = handlers.get(handler) as InternalInvokeHandler<Res, Req, ResErr, ReqErr, EOpts, M, IM> | undefined
-  if (!internalHandler) {
-    const streamStates = new Map<string, ReadableStreamDefaultController<Req>>()
-    const abortControllers = new Map<string, AbortController>()
-    const abortReasons = new Map<string, unknown>()
-    const scheduleAbort = (controller: AbortController, reason: unknown) => {
-      // NOTICE: use microtask to avoid aborting before the handler starts.
-      // This is important when the handler creates streams or async iterables
-      if (typeof queueMicrotask !== 'undefined') {
-        queueMicrotask(() => controller.abort(reason))
-        return
-      }
+  const existingHandler = handlers.get(handler) as InternalInvokeHandler<Res, Req, ResErr, ReqErr, EOpts, M, IM> | undefined
+  if (existingHandler) {
+    return () => {
+      ctx.off(event.sendEvent, existingHandler.onSend)
+      ctx.off(event.sendEventStreamEnd, existingHandler.onSendStreamEnd)
+      ctx.off(event.sendEventAbort, existingHandler.onSendAbort)
+      existingHandler.cleanup()
+    }
+  }
 
-      Promise.resolve().then(() => controller.abort(reason))
+  const streamStates = new Map<string, ReadableStreamDefaultController<Req>>()
+  const abortControllers = new Map<string, AbortController>()
+  const abortReasons = new Map<string, unknown>()
+
+  const scheduleAbort = (controller: AbortController, reason: unknown) => {
+    // NOTICE: use microtask to avoid aborting before the handler starts.
+    // This is important when the handler creates streams or async iterables
+    if (typeof queueMicrotask !== 'undefined') {
+      queueMicrotask(() => controller.abort(reason))
+      return
     }
 
-    const handleInvoke = async (invokeId: string, payload: Req, options?: EOpts) => {
-      const abortController = new AbortController()
-      abortControllers.set(invokeId, abortController)
+    Promise.resolve().then(() => {
+      return controller.abort(reason)
+    })
+  }
 
-      if (abortReasons.has(invokeId)) {
-        scheduleAbort(abortController, abortReasons.get(invokeId))
-      }
+  const ctxSignal = ctx.signal
 
-      const handlerOptions = options
-        ? { ...options, abortController }
-        : ({ abortController } as EOpts & { abortController: AbortController })
-
-      try {
-        const response = await handler(payload as Req, handlerOptions) // Call the handler function with the request payload
-        ctx.emit(
-          { ...defineEventa(`${event.receiveEvent.id}-${invokeId}`), invokeType: event.receiveEvent.invokeType } as ReceiveEvent<ExtendableInvokeResponse<Res, InvocableEventContext<CtxExt, EOpts>>, M, IM>,
-          { invokeId, content: response },
-          options,
-        ) // emit: event_response
-      }
-      catch (error) {
-        // TODO: to error object
-        ctx.emit(
-          { ...defineEventa(`${event.receiveEventError.id}-${invokeId}`), invokeType: event.receiveEventError.invokeType } as ReceiveEventError<Res, Req, ResErr, ReqErr, M, IM>,
-          { invokeId, content: { error: error as ResErr } },
-          options,
-        )
-      }
-      finally {
-        abortControllers.delete(invokeId)
-        abortReasons.delete(invokeId)
-      }
+  const onCtxAbort = () => {
+    for (const controller of abortControllers.values()) {
+      scheduleAbort(controller, ctxSignal?.reason)
     }
 
-    const onSend = async (payload: Eventa<NonNullable<SendEvent<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_trigger
-      if (!payload.body) {
-        return
-      }
-      if (!payload.body.invokeId) {
-        return
-      }
-
-      const invokeId = payload.body.invokeId
-      if (payload.body.isReqStream) {
-        let controller = streamStates.get(invokeId)
-        if (!controller) {
-          let localController: ReadableStreamDefaultController<Req>
-          const reqStream = new ReadableStream<Req>({
-            start(c) {
-              localController = c
-            },
-          })
-
-          controller = localController!
-          streamStates.set(invokeId, controller)
-          // TODO: perhaps, can we correctly write type Req here?
-          handleInvoke(invokeId, reqStream as Req, options)
-        }
-
-        controller.enqueue(payload.body.content as Req)
-        return
-      }
-
-      handleInvoke(invokeId, payload.body?.content as Req, options)
+    for (const controller of streamStates.values()) {
+      controller.error(createAbortError(ctxSignal?.reason))
     }
 
-    const onSendStreamEnd = (payload: Eventa<NonNullable<SendEventStreamEnd<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_stream_end
-      if (!payload.body) {
-        return
-      }
-      if (!payload.body.invokeId) {
-        return
-      }
+    streamStates.clear()
+  }
 
-      const invokeId = payload.body.invokeId
+  if (ctxSignal.aborted) {
+    onCtxAbort()
+  }
+  else {
+    ctxSignal.addEventListener('abort', onCtxAbort, { once: true })
+  }
+
+  const handleInvoke = async (invokeId: string, payload: Req, options?: EOpts) => {
+    const abortController = new AbortController()
+    abortControllers.set(invokeId, abortController)
+
+    if (ctxSignal.aborted) {
+      scheduleAbort(abortController, ctxSignal.reason)
+    }
+    if (abortReasons.has(invokeId)) {
+      scheduleAbort(abortController, abortReasons.get(invokeId))
+    }
+
+    const handlerOptions = options
+      ? { ...options, abortController }
+      : ({ abortController } as EOpts & { abortController: AbortController })
+
+    try {
+      const response = await handler(payload as Req, handlerOptions) // Call the handler function with the request payload
+      ctx.emit(
+        { ...defineEventa(`${event.receiveEvent.id}-${invokeId}`), invokeType: event.receiveEvent.invokeType } as ReceiveEvent<ExtendableInvokeResponse<Res, InvocableEventContext<CtxExt, EOpts>>, M, IM>,
+        { invokeId, content: response },
+        options,
+      ) // emit: event_response
+    }
+    catch (error) {
+      // TODO: to error object
+      ctx.emit(
+        { ...defineEventa(`${event.receiveEventError.id}-${invokeId}`), invokeType: event.receiveEventError.invokeType } as ReceiveEventError<Res, Req, ResErr, ReqErr, M, IM>,
+        { invokeId, content: { error: error as ResErr } },
+        options,
+      )
+    }
+    finally {
+      abortControllers.delete(invokeId)
+      abortReasons.delete(invokeId)
+    }
+  }
+
+  const onSend = async (payload: Eventa<NonNullable<SendEvent<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_trigger
+    if (!payload.body) {
+      return
+    }
+    if (!payload.body.invokeId) {
+      return
+    }
+
+    const invokeId = payload.body.invokeId
+    if (payload.body.isReqStream) {
       let controller = streamStates.get(invokeId)
       if (!controller) {
         let localController: ReadableStreamDefaultController<Req>
@@ -526,64 +531,99 @@ export function defineInvokeHandler<
         handleInvoke(invokeId, reqStream as Req, options)
       }
 
-      controller.close()
-      streamStates.delete(invokeId)
+      controller.enqueue(payload.body.content as Req)
+      return
     }
 
-    const onSendAbort = (payload: Eventa<NonNullable<SendEventAbort<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_abort
-      if (!payload.body) {
-        return
-      }
-      if (!payload.body.invokeId) {
-        return
-      }
-
-      const invokeId = payload.body.invokeId
-      const reason = payload.body.content
-      const abortController = abortControllers.get(invokeId)
-      if (!abortController) {
-        abortReasons.set(invokeId, reason)
-
-        let streamController = streamStates.get(invokeId)
-        if (!streamController) {
-          let localController: ReadableStreamDefaultController<Req>
-          const reqStream = new ReadableStream<Req>({
-            start(c) {
-              localController = c
-            },
-          })
-
-          streamController = localController!
-          streamStates.set(invokeId, streamController)
-          handleInvoke(invokeId, reqStream as Req, options)
-        }
-
-        streamController.error(createAbortError(reason))
-        streamStates.delete(invokeId)
-        return
-      }
-
-      scheduleAbort(abortController, reason)
-
-      const streamController = streamStates.get(invokeId)
-      if (streamController) {
-        streamController.error(createAbortError(reason))
-        streamStates.delete(invokeId)
-      }
-    }
-
-    internalHandler = { onSend, onSendStreamEnd, onSendAbort }
-    handlers.set(handler, internalHandler)
-
-    ctx.on(event.sendEvent, internalHandler.onSend)
-    ctx.on(event.sendEventStreamEnd, internalHandler.onSendStreamEnd)
-    ctx.on(event.sendEventAbort, internalHandler.onSendAbort)
+    handleInvoke(invokeId, payload.body?.content as Req, options)
   }
 
+  const onSendStreamEnd = (payload: Eventa<NonNullable<SendEventStreamEnd<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_stream_end
+    if (!payload.body) {
+      return
+    }
+    if (!payload.body.invokeId) {
+      return
+    }
+
+    const invokeId = payload.body.invokeId
+    let controller = streamStates.get(invokeId)
+    if (!controller) {
+      let localController: ReadableStreamDefaultController<Req>
+      const reqStream = new ReadableStream<Req>({
+        start(c) {
+          localController = c
+        },
+      })
+
+      controller = localController!
+      streamStates.set(invokeId, controller)
+      // TODO: perhaps, can we correctly write type Req here?
+      handleInvoke(invokeId, reqStream as Req, options)
+    }
+
+    controller.close()
+    streamStates.delete(invokeId)
+  }
+
+  const onSendAbort = (payload: Eventa<NonNullable<SendEventAbort<Res, Req, ResErr, ReqErr, M, IM>['body']>>, options?: EOpts) => { // on: event_abort
+    if (!payload.body) {
+      return
+    }
+    if (!payload.body.invokeId) {
+      return
+    }
+
+    const invokeId = payload.body.invokeId
+    const reason = payload.body.content
+    const abortController = abortControllers.get(invokeId)
+    if (!abortController) {
+      abortReasons.set(invokeId, reason)
+
+      let streamController = streamStates.get(invokeId)
+      if (!streamController) {
+        let localController: ReadableStreamDefaultController<Req>
+        const reqStream = new ReadableStream<Req>({
+          start(c) {
+            localController = c
+          },
+        })
+
+        streamController = localController!
+        streamStates.set(invokeId, streamController)
+        handleInvoke(invokeId, reqStream as Req, options)
+      }
+
+      streamController.error(createAbortError(reason))
+      streamStates.delete(invokeId)
+      return
+    }
+
+    scheduleAbort(abortController, reason)
+
+    const streamController = streamStates.get(invokeId)
+    if (streamController) {
+      streamController.error(createAbortError(reason))
+      streamStates.delete(invokeId)
+    }
+  }
+
+  const cleanup = () => {
+    ctxSignal.removeEventListener('abort', onCtxAbort)
+  }
+
+  const internalHandler = { onSend, onSendStreamEnd, onSendAbort, cleanup }
+  handlers.set(handler, internalHandler)
+
+  ctx.on(event.sendEvent, internalHandler.onSend)
+  ctx.on(event.sendEventStreamEnd, internalHandler.onSendStreamEnd)
+  ctx.on(event.sendEventAbort, internalHandler.onSendAbort)
+
   return () => {
-    ctx.off(event.sendEvent, internalHandler!.onSend)
-    ctx.off(event.sendEventStreamEnd, internalHandler!.onSendStreamEnd)
-    ctx.off(event.sendEventAbort, internalHandler!.onSendAbort)
+    ctx.off(event.sendEvent, internalHandler.onSend)
+    ctx.off(event.sendEventStreamEnd, internalHandler.onSendStreamEnd)
+    ctx.off(event.sendEventAbort, internalHandler.onSendAbort)
+    internalHandler.cleanup()
   }
 }
 
@@ -659,12 +699,14 @@ export function undefineInvokeHandler<
   event: InvokeEventa<Res, Req, ResErr, ReqErr>,
   handler?: Handler<Res, Req, InvocableEventContext<CtxExt, EOpts>, EOpts>,
 ): boolean {
-  if (!ctx.invokeHandlers)
+  if (!ctx.invokeHandlers) {
     return false
+  }
 
   const handlers = ctx.invokeHandlers?.get(event.sendEvent.id)
-  if (!handlers)
+  if (!handlers) {
     return false
+  }
 
   if (handler) {
     const internalHandler = handlers.get(handler)
@@ -674,16 +716,19 @@ export function undefineInvokeHandler<
     ctx.off(event.sendEvent, internalHandler.onSend)
     ctx.off(event.sendEventStreamEnd, internalHandler.onSendStreamEnd)
     ctx.off(event.sendEventAbort, internalHandler.onSendAbort)
+    internalHandler.cleanup()
     ctx.invokeHandlers.delete(event.sendEvent.id)
 
     return true
   }
 
   let returnValue = false
+
   for (const internalHandlers of handlers.values()) {
     ctx.off(event.sendEvent, internalHandlers.onSend)
     ctx.off(event.sendEventStreamEnd, internalHandlers.onSendStreamEnd)
     ctx.off(event.sendEventAbort, internalHandlers.onSendAbort)
+    internalHandlers.cleanup()
     returnValue = true
   }
 


### PR DESCRIPTION
## What changed

- Added channel helpers for one-way fan-out and bidirectional mesh linking.
- Added channel plugins for transform/filter behavior, group-level and edge-local use, and abort propagation controls.
- Updated invoke handler cancellation so context abort reaches active handler abort controllers.
- Documented pipe/link usage, transform/filter plugins, mesh semantics, and abort propagation in the README.

## Validation

- pnpm test:run
- pnpm typecheck
- pnpm lint