### PR TITLE
test: run Vitest browser projects headlessly

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(({ mode }) => {
             exclude: ['**/node_modules/**'],
             browser: {
               enabled: true,
+              headless: true,
               provider: playwright(),
               instances: [
                 { browser: 'chromium' },


### PR DESCRIPTION
## Summary

Run the Vitest Browser project in headless mode. The tests still use Playwright Chromium, but local runs no longer open a visible browser window.

## Verification

- `pnpm test:run`
- `pnpm typecheck`
- `pnpm lint`